### PR TITLE
Update previously changed method names

### DIFF
--- a/lib/client_authenticator/test_helpers.rb
+++ b/lib/client_authenticator/test_helpers.rb
@@ -3,13 +3,13 @@ require 'client_authenticator'
 module ClientAuthenticator
   module TestHelpers
     def stub_valid_client_credentials
-      expect(ClientAuthenticator::ApiClient).to receive(:authenticate!).with('client_id', 'valid_pass_key').and_return(true)
+      expect(ClientAuthenticator::ApiClient).to receive(:authenticate_client!).with('client_id', 'valid_pass_key').and_return(true)
       @request.headers['client-id'] = 'client_id'
       @request.headers['pass-key'] = 'valid_pass_key'
     end
 
     def stub_invalid_client_credentials
-      expect(ClientAuthenticator::ApiClient).to receive(:authenticate!).with('client_id', 'invalid_pass_key').and_return(false)
+      expect(ClientAuthenticator::ApiClient).to receive(:authenticate_client!).with('client_id', 'invalid_pass_key').and_return(false)
       @request.headers['client-id'] = 'client_id'
       @request.headers['pass-key'] = 'invalid_pass_key'
     end


### PR DESCRIPTION
The `authenticate!` method name was changed to `authenticate_client!`, but was not updated in `test_helper.rb`. Hence, using the stubbing helper methods `stub_valid_client_credentials` and `stub_invalid_client_credentials` was throwing errors.

This PR fixes the above error by renaming the methods to `authenticate_client!`